### PR TITLE
Fix for VC2010 compile error in GLFW template

### DIFF
--- a/templates/glfw/flextGL.c.template
+++ b/templates/glfw/flextGL.c.template
@@ -13,10 +13,13 @@ void flextLoadOpenglFunctions();
 
 int flextInit() 
 {
-    flextLoadOpenglFunctions();
-
+#if $version.major*10 + $version.minor >= 32 and not $version.core
+    GLint profile;
+#end if
     int minor = glfwGetWindowParam(GLFW_OPENGL_VERSION_MINOR);
     int major = glfwGetWindowParam(GLFW_OPENGL_VERSION_MAJOR);
+
+    flextLoadOpenglFunctions();
 
     if (major < $version.major || (major == $version.major && minor < $version.minor)) {
         fprintf(stderr, "Error: OpenGL version $(version.major).$(version.minor) not supported.\n");
@@ -26,8 +29,6 @@ int flextInit()
     }
 
 #if $version.major*10 + $version.minor >= 32 and not $version.core
-    GLint profile;
-    
     glGetIntegerv(GL_CONTEXT_PROFILE_MASK, &profile);
 
     if ((profile & GL_CONTEXT_COMPATIBILITY_PROFILE_BIT) == 0) {


### PR DESCRIPTION
The archaic C compiler in VC2010 apparently doesn't like variables to be mixed with code. I've edited the GLFW template to correct this so that it compiles without error.
