### PR TITLE
Less optimistic stripping of duplicate commands

### DIFF
--- a/flext.py
+++ b/flext.py
@@ -293,10 +293,13 @@ def generate_functions(subsets, commands):
     function_set = set()
     
     for subset in subsets:
-        #remove 'gl' suffixes and strip away commands that are already required by a preceding feature or extension
-        subset_functions = [Function(commands[name].returntype, commands[name].name[2:], commands[name].params) for name in subset.commands if name not in function_set]
-        function_set = function_set.union(subset.commands)
-            
+        #remove 'gl' suffixes and strip away commands that are already in the list
+        subset_functions = []
+        for name in subset.commands:
+            if name in function_set: continue
+            subset_functions.append(Function(commands[name].returntype, commands[name].name[2:], commands[name].params))
+            function_set.add(name)
+
         functions.append((subset.name, subset_functions))
 
     return functions


### PR DESCRIPTION
Currently in the `gl.xml` file there is duplicated `glGetPointerv()` in GL 4.3 and also  `glProgramUniformMatrix4fvEXT()` in `EXT_separate_shader_objects` ES extension. It's thus needed to remove duplicates also inside the subset itself (at least until the XML file is fixed).

Maybe this isn't exactly pythonic way to do it, but nothing better came to my mind :-)
