### PR TITLE
Respect API/profile restrictions for extensions, if specified in the gl.xml file

### DIFF
--- a/flext.py
+++ b/flext.py
@@ -60,9 +60,11 @@ def download_spec(always_download = False):
 
 class Version():
     def __init__(self, major, minor, profile_or_api):
+        # 'gl', 'gles1' or 'gles2'
         self.api = 'gl' + profile_or_api if profile_or_api in ['es1', 'es2'] else 'gl'
         self.major = int(major)
         self.minor = int(minor)
+        # 'core' or 'compatibility'
         self.profile = profile_or_api if self.api == 'gl' else ''
 
     def __str__(self):


### PR DESCRIPTION
Affects mainly GLES and KHR extensions, desktop GL (where majority of KHR extensions is already in core) not so much. 

For example, `KHR_debug` extension names are without `KHR` suffix on desktop GL, but they *do* have the suffix on ES. Currently, if `KHR_debug` extension was requested either on desktop or on ES, it resulted in both `glObjectLabel()` and `glObjectLabelKHR()` being added to the generated files, which may be
confusing and error-prone to use and may cause the "get proc address" code to complain that one of these functions is not found. Relevant snippet from the file:
```xml
<extension name="GL_KHR_debug" supported="gl|glcore|gles2">
    <require api="gl" comment="KHR extensions *mandate* suffixes for ES, unlike for GL">
        <enum name="GL_DEBUG_OUTPUT_SYNCHRONOUS"/>
        <enum name="GL_DEBUG_NEXT_LOGGED_MESSAGE_LENGTH"/>
        <enum name="GL_DEBUG_CALLBACK_FUNCTION"/>
        <enum name="GL_DEBUG_CALLBACK_USER_PARAM"/>
        ...
        <command name="glDebugMessageControl"/>
        <command name="glDebugMessageInsert"/>
        <command name="glDebugMessageCallback"/>
        <command name="glGetDebugMessageLog"/>
        ...
    </require>
    <require api="gles2">
        <enum name="GL_DEBUG_OUTPUT_SYNCHRONOUS_KHR"/>
        <enum name="GL_DEBUG_NEXT_LOGGED_MESSAGE_LENGTH_KHR"/>
        <enum name="GL_DEBUG_CALLBACK_FUNCTION_KHR"/>
        <enum name="GL_DEBUG_CALLBACK_USER_PARAM_KHR"/>
        ...
        <command name="glDebugMessageControlKHR"/>
        <command name="glDebugMessageInsertKHR"/>
        <command name="glDebugMessageCallbackKHR"/>
        <command name="glGetDebugMessageLogKHR"/>
        ...
    </require>
    <require api="gl" profile="compatibility">
        <enum name="GL_DISPLAY_LIST"/>
    </require>
</extension>
```

Another example is `ARB_robustness` on core desktop profile, which now doesn't contain functions like `glGetnHistogramARB()` that were only part of the compatibility profile. Sadly this is not true for `EXT_direct_state_access` names, which are not properly marked in the XML and thus still include ugly compatibility-profile-only names like `glMatrixPushEXT()`.

In short, this change should result in slightly shorter generated files without irrelevant "noise".