### PR TITLE
Ability to blacklist functions next to whitelisting.

### DIFF
--- a/flextGLgen.py
+++ b/flextGLgen.py
@@ -8,13 +8,13 @@ import flext
 def main():
     # Read command line arguments and profile settings
     options,profile = parse_args()    
-    version,extensions,funcslist = flext.parse_profile(profile)
+    version,extensions,funcslist,funcsblacklist = flext.parse_profile(profile)
 
     # Download spec file(s) if necessary
     flext.download_spec(options.download)
 
     # Parse spec
-    passthru, enums, functions, types, raw_enums = flext.parse_xml(version, extensions, funcslist)
+    passthru, enums, functions, types, raw_enums = flext.parse_xml(version, extensions, funcslist, funcsblacklist)
 
     # Generate source from templates
     flext.generate_source(options, version, enums, functions, passthru,

--- a/profiles/exampleProfile.txt
+++ b/profiles/exampleProfile.txt
@@ -28,10 +28,11 @@ extension ARB_gpu_shader5 required
 # for checking if an extension is supported.
 
 
-# An optional whitelist of functions to load can be supplied
+# An optional whitelist/blacklist of functions to load can be supplied
 # This allows reducing the generated code size and loading times
 # 'begin functions' starts a space-separated list of functions to be loaded and
-# 'end functions' ends it. Comments still work.
+# 'end functions' ends it. If you say 'functions blacklist' instead of
+# 'functions', the listed functions will be blacklisted. Comments still work.
 # The 'gl' at the beginning of function names should be omitted
 
 begin functions


### PR DESCRIPTION
Added a new `begin|end functions blacklist` section to the profile file, functions listed there will be skipped. If a function is both in a whitelist and a blacklist, it is blacklisted. Updated the sample profile
file to reflect the change.

My use case for this was disabling a few functions that were unconditionally added by `EXT_separate_shader_objects` but not supported on GLES2 (unsigned integer uniforms) and thus failing to link on iOS. I have hundreds of functions loaded and using the whitelist for this purpose would cause a maintenance nightmare.